### PR TITLE
remove depreciated call

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -15,7 +15,7 @@ aes_key = "DBn3Wrqd7rFHu8cgPXCnEzIWgaUXcRXzOplkskcy9fo="
 url = ARGV[0]
 
 
-iv = OpenSSL::Cipher::Cipher.new("AES-256-CBC").random_iv
+iv = OpenSSL::Cipher.new("AES-256-CBC").random_iv
 nonce = b64enc(iv)
 
 veri = encrypt(nonce, aes_key, iv)


### PR DESCRIPTION
OpenSSL::Cipher::Cipher is depreciated use OpenSSL::Cipher instead
http://ruby-doc.org/stdlib-1.9.3/libdoc/openssl/rdoc/OpenSSL/Cipher/Cipher.html